### PR TITLE
Simple Fix: Project Domain now becomes Project Name

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -542,7 +542,7 @@ exports.activate = (/** @type {vscode.ExtensionContext} */ context) => {
 
   async function fcPromptNewProjectInfo() {
     const persistentToken = await fcGetPersistentTokenQuiet();
-    const projectDomainPrompted = await vscode.window.showInputBox({prompt: 'Project Domain'});
+    const projectDomainPrompted = await vscode.window.showInputBox({prompt: 'Project Name'});
     if (!projectDomainPrompted) return null;
     const project = await glitchProjectFromDomain(persistentToken, projectDomainPrompted);
     return fcProjectInfoFromProject(project);


### PR DESCRIPTION
It has bugged me that when you go to open a project, it says "project domain" when it is supposed to be "project name." This fix fixes that. (I think)